### PR TITLE
Update the part2linkerscript

### DIFF
--- a/hw/bsp/dwm1001/bsp.yml
+++ b/hw/bsp/dwm1001/bsp.yml
@@ -26,7 +26,7 @@ bsp.linkerscript.BOOT_LOADER.OVERWRITE:
     - 'hw/bsp/dwm1001/boot-nrf52xxaa.ld'
     - '@apache-mynewt-core/hw/mcu/nordic/nrf52xxx/nrf52.ld'
 
-bsp.part2linkerscript: "hw/bsp/dwm1001/split-nrf52-thingy.ld"
+bsp.part2linkerscript: "hw/bsp/dwm1001/split-nrf52.ld"
 bsp.downloadscript: "hw/bsp/dwm1001/dwm1001_download.sh"
 bsp.debugscript: "hw/bsp/dwm1001/dwm1001_debug.sh"
 bsp.downloadscript.WINDOWS.OVERWRITE: "hw/bsp/dwm1001/dmw1001_download.cmd"


### PR DESCRIPTION
As the issues, when use the bsp dwm1001, if use the mynewt apps/splitty, can't open split-nrf52-thingy.ld, on this folder, it's may be split-nrf52.ld.