### PR TITLE
Removed the nrf5alarminit/deinit from lib/openthread

### DIFF
--- a/lib/openthread/include/openthread/ot_common.h
+++ b/lib/openthread/include/openthread/ot_common.h
@@ -83,8 +83,6 @@ void ot_post_init(dw1000_dev_instance_t * inst, otInstance *aInstance);
 void
 ot_free(ot_instance_t * inst);
 
-void nrf5AlarmInit(dw1000_dev_instance_t* inst);
-
 void RadioInit(dw1000_dev_instance_t* inst);
 
 void nrf5AlarmDeinit();

--- a/lib/openthread/include/openthread/ot_common.h
+++ b/lib/openthread/include/openthread/ot_common.h
@@ -85,8 +85,6 @@ ot_free(ot_instance_t * inst);
 
 void RadioInit(dw1000_dev_instance_t* inst);
 
-void nrf5AlarmDeinit();
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/openthread/src/ot_common.c
+++ b/lib/openthread/src/ot_common.c
@@ -229,7 +229,6 @@ ot_init(dw1000_dev_instance_t * inst){
 	
     ot_global_inst = inst->ot;
     
-    nrf5AlarmInit(inst);
     RadioInit(inst);
 	
     return inst->ot;


### PR DESCRIPTION
As the alarm.c is defined in the openthread application,  removed the init and deinit from core and added in the openthread app