### PR TITLE
Fix DW1000 shell cmd struct initialization

### DIFF
--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_cli.c
+++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_cli.c
@@ -68,7 +68,7 @@ static struct shell_cmd shell_dw1000_cmd = {
     .sc_cmd = "dw1000",
     .sc_cmd_func = dw1000_cli_cmd,
 #if MYNEWT_VAL(SHELL_CMD_HELP)
-    &cmd_dw1000_help
+    .help = &cmd_dw1000_help
 #endif
 };
 


### PR DESCRIPTION
I was getting the following error when compiling the twr_node_tdma example:
```
Error: repos/mynewt-dw1000-core/hw/drivers/uwb/uwb_dw1000/src/dw1000_cli.c:71:5: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
     &cmd_dw1000_help
     ^
```
I turns out a field name was missing on a struct initialization.