### PR TITLE
Fixes to allow ttk1000 bsp to work

### DIFF
--- a/hw/bsp/ttk1000/src/hal_bsp.c
+++ b/hw/bsp/ttk1000/src/hal_bsp.c
@@ -119,7 +119,7 @@ struct stm32_hal_spi_cfg os_bsp_spi0m_cfg = {
     .mosi_pin = MCU_GPIO_PORTB(5),
     .irq_prio = 2,
 };
-struct os_sem g_spi0_sem;
+struct dpl_sem g_spi0_sem;
 #endif
 
 #if MYNEWT_VAL(ETH_0)

--- a/hw/bsp/ttk1000/syscfg.yml
+++ b/hw/bsp/ttk1000/syscfg.yml
@@ -60,8 +60,8 @@ syscfg.defs:
         description: 'BAUDRATE_LOW 2000kHz'
         value: 2000
     DW1000_DEVICE_BAUDRATE_HIGH:
-        description: 'BAUDRATE_HIGH 4000kHz'
-        value: 8000
+        description: 'BAUDRATE_HIGH (max 20000kHz)'
+        value: 20000
     DW1000_DEVICE_0_TX_ANT_DLY:
         description: 'TX_ANT_DLY'
         value: 0x4042

--- a/hw/bsp/ttk1000/ttk1000_debug.sh
+++ b/hw/bsp/ttk1000/ttk1000_debug.sh
@@ -27,11 +27,23 @@
 #  - RESET set if target should be reset when attaching
 #  - NO_GDB set if we should not start gdb to debug
 #
-. $CORE_PATH/hw/scripts/openocd.sh
 
-FILE_NAME=$BIN_BASENAME.elf
-CFG="-f board/stm32f429discovery.cfg"
-# Exit openocd when gdb detaches.
-EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {if {[stm32f4x.cpu curstate] eq \"halted\"} resume;shutdown}"
+if [ -z "$TTK1000_USE_STLINK" ];then
+    echo "using openocd"
+    . $CORE_PATH/hw/scripts/openocd.sh
 
-openocd_debug
+    FILE_NAME=$BIN_BASENAME.elf
+    CFG="-f board/stm32f429discovery.cfg"
+    # Exit openocd when gdb detaches.
+    EXTRA_JTAG_CMD="$EXTRA_JTAG_CMD; stm32f4x.cpu configure -event gdb-detach {if {[stm32f4x.cpu curstate] eq \"halted\"} resume;shutdown}"
+
+    openocd_debug
+else
+    echo "using stlink"
+    . $CORE_PATH/hw/scripts/stlink.sh
+
+    FILE_NAME=$BIN_BASENAME.elf
+    # Exit openocd when gdb detaches.
+
+    stlink_debug
+fi

--- a/hw/bsp/ttk1000/ttk1000_download.sh
+++ b/hw/bsp/ttk1000/ttk1000_download.sh
@@ -28,14 +28,27 @@
 #  - MFG_IMAGE is "1" if this is a manufacturing image
 #  - FLASH_OFFSET contains the flash offset to download to
 #  - BOOT_LOADER is set if downloading a bootloader
-. $CORE_PATH/hw/scripts/openocd.sh
 
-CFG="-f board/stm32f429discovery.cfg"
+if [ -z "$TTK1000_USE_STLINK" ];then
+    echo "using openocd"
+    . $CORE_PATH/hw/scripts/openocd.sh
+    CFG="-f board/stm32f429discovery.cfg"
+    if [ "$MFG_IMAGE" ]; then
+        FLASH_OFFSET=0x08000000
+    fi
 
-if [ "$MFG_IMAGE" ]; then
-    FLASH_OFFSET=0x08000000
+    common_file_to_load
+
+    openocd_load
+    openocd_reset_run
+else
+    echo "using stlink"
+    . $CORE_PATH/hw/scripts/stlink.sh
+
+    if [ "$MFG_IMAGE" ]; then
+        FLASH_OFFSET=0x08000000
+    fi
+
+    common_file_to_load
+    stlink_load
 fi
-
-common_file_to_load
-openocd_load
-openocd_reset_run


### PR DESCRIPTION
OBS requires mynewt_1_6_0 due to spi_txrx not handling rxbuffer being set to 0 in earlier versions of mynewt. 